### PR TITLE
Fix en passant capture flag and resolve build warnings

### DIFF
--- a/bitboard/bitboard.cpp
+++ b/bitboard/bitboard.cpp
@@ -11,6 +11,7 @@
 #include "../utility/randomutility.h"
 #include <array>
 #include <iostream>
+#include <cstring>
 #include <vector>
 
 #define copy_board()                                                           \
@@ -37,10 +38,9 @@ Game::Game(std::array<ull, NUM_SQ> rookMagics,
            int castle, int halfMoves, int fullMoves,
            std::array<ull, NUM_BITBOARDS> pieceBitboards,
            std::array<ull, NUM_OCCUPANCIES> occupancyBitboards)
-    : rookMagics(rookMagics), bishopMagics(bishopMagics), side(side),
-      enPassant(enPassant), castle(castle), halfMoves(halfMoves),
-      fullMoves(fullMoves), pieceBitboards(pieceBitboards),
-      occupancyBitboards(occupancyBitboards) {
+    : pieceBitboards(pieceBitboards), occupancyBitboards(occupancyBitboards),
+      side(side), enPassant(enPassant), castle(castle), halfMoves(halfMoves),
+      fullMoves(fullMoves), rookMagics(rookMagics), bishopMagics(bishopMagics) {
   init_leaper_attacks();
   init_slider_attacks(rook);
   init_slider_attacks(bishop);
@@ -49,9 +49,9 @@ Game::Game(std::array<ull, NUM_SQ> rookMagics,
 Game::Game(int side, int enPassant, int castle, int halfMoves, int fullMoves,
            std::array<ull, NUM_BITBOARDS> pieceBitboards,
            std::array<ull, NUM_OCCUPANCIES> occupancyBitboards)
-    : side(side), enPassant(enPassant), castle(castle), halfMoves(halfMoves),
-      fullMoves(fullMoves), pieceBitboards(pieceBitboards),
-      occupancyBitboards(occupancyBitboards) {
+    : pieceBitboards(pieceBitboards), occupancyBitboards(occupancyBitboards),
+      side(side), enPassant(enPassant), castle(castle), halfMoves(halfMoves),
+      fullMoves(fullMoves) {
   init_all();
 }
 
@@ -220,7 +220,7 @@ inline void Game::loop_attacks(int sourceSquare, ull attackBitboard, int piece,
       if (isPawn) {
         if (targetSquare == this->enPassant)
           moveList.push_back(
-              encode_move(sourceSquare, targetSquare, piece, 0, 0, 0, 0, 1));
+              encode_move(sourceSquare, targetSquare, piece, 0, 0, 1, 0, 1));
       } else
         moveList.push_back(
             encode_move(sourceSquare, targetSquare, piece, 0, 0, 0, 0, 0));
@@ -258,7 +258,7 @@ std::vector<int> Game::generate_moves() {
   std::string curColor = side == white ? "white" : "black";
   int otherSide = 1 - this->side;
   int sourceSquare, targetSquare;
-  ull bitboardCopy, attackBitboard;
+  ull bitboardCopy, attackBitboard = 0;
   int lowerPiece = (side ? p : P);
   int upperPiece = (side ? k : K);
   for (int piece = lowerPiece; piece <= upperPiece; piece++) {

--- a/tests/enPassantCaptureTest.cpp
+++ b/tests/enPassantCaptureTest.cpp
@@ -1,0 +1,20 @@
+#include "../bitboard/bitboard.h"
+#include "../utility/parsefen.h"
+#include "../utility/macros.h"
+#include <gtest/gtest.h>
+
+TEST(EnPassant, CaptureFlagSet) {
+  Game game(rookMagics, bishopMagics);
+  std::string fen = "8/8/8/3pP3/8/8/8/8 w - d6 0 1";
+  parse_fen(game, fen);
+  auto moves = game.generate_moves();
+  int expected = encode_move(e5, d6, P, 0, 0, 1, 0, 1);
+  bool found = false;
+  for (int move : moves) {
+    if (move == expected) {
+      found = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(found);
+}

--- a/utility/parsefen.cpp
+++ b/utility/parsefen.cpp
@@ -1,5 +1,5 @@
 #include "../bitboard/bitboard.h"
-#include <_ctype.h>
+#include <cctype>
 #include <cassert>
 #include <iostream>
 #include <string>

--- a/utility/timerutility.cpp
+++ b/utility/timerutility.cpp
@@ -1,6 +1,7 @@
 #include "../utility/macros.h"
 #include <chrono>
 #include <memory>
+#include <atomic>
 #include <thread>
 ull getMilliseconds() {
   // Get the current time from the system clock


### PR DESCRIPTION
## Summary
- mark en passant moves as captures in move generation
- add missing includes and reorder Game constructors to satisfy -Werror
- add regression test ensuring en passant capture is flagged

## Testing
- `make tests` *(fails: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689cb3d774048330b21a796a655f5002